### PR TITLE
Update README.md with "Native library notes" and .travis.yml to use zef.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,8 +7,8 @@ perl6:
     - latest
 sudo: true
 install:
-    - rakudobrew build-panda
-    - panda installdeps .
+    - rakudobrew build-zef
+    - zef --depsonly install .
 before_install:
     - sudo apt-get -qq update
     - sudo apt-get install -qq -y libodbc1

--- a/README.md
+++ b/README.md
@@ -1,1 +1,7 @@
 # DBDish::ODBC
+
+## Native library notes
+
+Requires ODBC library.  If you believe you have a library installed but
+see error messages complaining that it is missing, try the
+`DBDISH_ODBC_LIB` environment variable.


### PR DESCRIPTION
rakudubrew build-panda no longer works so update .travis.yml to use zef.  CI will still fail, the same way it did on the last commit.

Update README.md with "Native library notes" for squashathon [ecosystem-unbitrot #248](https://github.com/perl6/ecosystem-unbitrot/issues/248).