### PR TITLE
Fix error reporting

### DIFF
--- a/lib/DBDish/ODBC/Connection.pm6
+++ b/lib/DBDish/ODBC/Connection.pm6
@@ -11,7 +11,7 @@ has Str $.fconn-str;
 submethod BUILD(:$!conn!, :$!fconn-str!, :$!parent!, :$!RaiseError) { };
 
 method !handle-error($rep) {
-    $rep ~~ ODBCErr ?? self!set-err(|$rep) !! $rep
+    $rep ~~ ODBCErr ?? self!set-err(|$rep.list) !! $rep
 }
 
 method prepare(Str $statement, *%args) {

--- a/lib/DBDish/ODBC/Native.pm6
+++ b/lib/DBDish/ODBC/Native.pm6
@@ -250,7 +250,10 @@ class SQL_HANDLE is repr('CPointer') {
                 :$state, :$native, :native-message($message),
                 :handle(self.^name)
             ).fail if $throw;
-            $rep .= new(:list($code, "$state {$message.subbuf(^$etl)}"));
+            $rep .= new(
+               :list($code, "$state {$message.subbuf(^$etl)}"),
+               :hash(%(:$code))
+           );
 	    }
 	    else { fail "Can't allocate the ENV Handle" }
 	    $rep;

--- a/lib/DBDish/ODBC/Native.pm6
+++ b/lib/DBDish/ODBC/Native.pm6
@@ -236,24 +236,21 @@ class SQL_HANDLE is repr('CPointer') {
 	if $code +& SQL_SUCCESS_MASK {
 	    my ODBCErr $rep;
 	    if self { # On allocated handle
-		my $ret = SQL_SUCCESS;
-		my utf8 $state .= allocate(5);
-		my int32 $native;
-		my utf8 $message .= allocate(256);
-		my int32 $etl;
-		my $i = 0;
-		$ret = SQLGetDiagRec(
-		    self.h-type, self, ++$i, $state, $native,
-		    $message, $message.elems, $etl
-		);
-		X::DBDish::ODBCNatErr.new(
-		    :$state, :$native, :native-message($message),
-		    :handle(self.^name)
-		).fail if $throw;
-		$rep .= new(
-		    :list(~$state, ~$message.subbuf(^$etl)),
-		    :hash(%(:$code))
-		);
+            my $ret = SQL_SUCCESS;
+            my utf8 $state .= allocate(5);
+            my int32 $native;
+            my utf8 $message .= allocate(256);
+            my int32 $etl;
+            my $i = 0;
+            $ret = SQLGetDiagRec(
+                self.h-type, self, ++$i, $state, $native,
+                $message, $message.elems, $etl
+            );
+            X::DBDish::ODBCNatErr.new(
+                :$state, :$native, :native-message($message),
+                :handle(self.^name)
+            ).fail if $throw;
+            $rep .= new(:list($code, "$state {$message.subbuf(^$etl)}"));
 	    }
 	    else { fail "Can't allocate the ENV Handle" }
 	    $rep;

--- a/lib/DBDish/ODBC/StatementHandle.pm6
+++ b/lib/DBDish/ODBC/StatementHandle.pm6
@@ -12,7 +12,7 @@ has @!param-type;
 has $!field_count;
 
 method !handle-error($rep) {
-    $rep ~~ ODBCErr ?? self!set-err(|$rep) !! $rep
+    $rep ~~ ODBCErr ?? self!set-err(|$rep.list) !! $rep
 }
 
 method !get-meta {


### PR DESCRIPTION
ODBCErr was constructed in a way it couldn't be processed by DBDish::ErrorHandling.set-err().
DBDish::ErrorHandling.set-err() only takes positional arguments, no nameds.